### PR TITLE
Upgrade plugin to be compatible with Jekyll 3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,14 @@
 name: Jekyll _Pages Directory Demo
 markdown: redcarpet
-pygments: false
+highlighter: false
 
 pages: ./_pages
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      layout: page
 
 exclude:
   - LICENSE

--- a/_pages/level-zero.html
+++ b/_pages/level-zero.html
@@ -1,5 +1,4 @@
 ---
-layout: page
 level: Zero
 ---
 <p class="zero-test">success</p>

--- a/_plugins/jekyll-pages-directory.rb
+++ b/_plugins/jekyll-pages-directory.rb
@@ -1,11 +1,8 @@
 module Jekyll
-
-
   class PagesDirGenerator < Generator
-
     def generate(site)
       pages_dir = site.config['pages'] || './_pages'
-      all_raw_paths = Dir["#{pages_dir}/**/*"]      
+      all_raw_paths = Dir["#{pages_dir}/**/*"]
       all_raw_paths.each do |f|
 
         if File.file?(File.join(site.source, '/', f))
@@ -13,10 +10,10 @@ module Jekyll
           clean_filepath = f.gsub(/^#{pages_dir}\//, '')
           clean_dir = extract_directory(clean_filepath)
 
-          site.pages << PagesDirPage.new(site, 
-                                         site.source, 
-                                         clean_dir, 
-                                         filename, 
+          site.pages << PagesDirPage.new(site,
+                                         site.source,
+                                         clean_dir,
+                                         filename,
                                          pages_dir)
 
         end
@@ -31,9 +28,7 @@ module Jekyll
         return ''
       end
     end
-
   end
-
 
   class PagesDirPage < Page
 
@@ -44,12 +39,13 @@ module Jekyll
       @name = name
 
       process(name)
-
       read_yaml(File.join(base, pagesdir, dir), name)
+
+      data.default_proc = proc do |hash, key|
+        site.frontmatter_defaults.find(File.join(dir, name), type, key)
+      end
+
+      Jekyll::Hooks.trigger :pages, :post_init, self
     end
-
   end
-
-
 end
-

--- a/spec/pages_dir_spec.rb
+++ b/spec/pages_dir_spec.rb
@@ -5,45 +5,45 @@ describe '_Pages Directory Generator' do
 
   it 'should create all the write files in the right places' do
     visit '/level-zero.html'
-    page.should have_css 'span#level-name', :text => 'Zero'
-    page.should have_css 'h1#title', :text => 'Generic Page Title'
+    expect(page).to have_css 'span#level-name', :text => 'Zero'
+    expect(page).to have_css 'h1#title', :text => 'Generic Page Title'
 
     visit '/level-one/index.html'
-    page.should have_css 'span#level-name', :text => 'One'
-    page.should have_css 'h1#title', :text => 'Generic Page Title'
+    expect(page).to have_css 'span#level-name', :text => 'One'
+    expect(page).to have_css 'h1#title', :text => 'Generic Page Title'
 
     visit '/level-one/level-two/index.html'
-    page.should have_css 'span#level-name', :text => 'Two'
-    page.should have_css 'h1#title', :text => 'Generic Page Title'
+    expect(page).to have_css 'span#level-name', :text => 'Two'
+    expect(page).to have_css 'h1#title', :text => 'Generic Page Title'
 
     visit '/level-one/level-two/top-level.html'
-    page.should have_css 'span#level-name', :text => 'Top'
-    page.should have_css 'h1#title', :text => 'Generic Page Title'
+    expect(page).to have_css 'span#level-name', :text => 'Top'
+    expect(page).to have_css 'h1#title', :text => 'Generic Page Title'
   end
 
   it 'should still properly handle page content' do
     visit '/level-one/level-two/top-level.html'
-    page.should have_css 'p#custom-content', :text => 'CUSTOM'
+    expect(page).to have_css 'p#custom-content', :text => 'CUSTOM'
   end
 
   it 'should not create a _pages directory in _site' do
-    File.exist?('_site/_pages').should == false
+    expect(File.exist?('_site/_pages')).to be_falsey
 
     visit '/_pages'
-    page.status_code.should == 404
+    expect(page.status_code).to eq 404
 
     visit '/_pages/level-zero.html'
-    page.status_code.should == 404
+    expect(page.status_code).to eq 404
   end
 
   it 'should include the zero item test content' do
     visit '/level-zero.html'
-    page.should have_css 'p.zero-test', :text => 'success'
+    expect(page).to have_css 'p.zero-test', :text => 'success'
   end
 
   it 'should render index.php properly' do
     visit '/index.html'
-    page.should have_css 'div#home-test', :text => 'home success'
+    expect(page).to have_css 'div#home-test', :text => 'home success'
   end
 
 end


### PR DESCRIPTION
* Resolves issue with default template not being detected
* Update config file to use highlighter option instead of pygments
* Update spec to use rspec expect syntax (stops deprecation warnings)